### PR TITLE
Move header and score to sidebar

### DIFF
--- a/client/components/Game.js
+++ b/client/components/Game.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 
 import Card from './Card';
-import Options from './Options';
 
 import newGame from '../utils/newGame';
 
@@ -20,27 +19,6 @@ class Game extends Component {
   constructor (props) {
     super(props);
     this.returnState = null;
-    this.startNewGame = this.startNewGame.bind(this);
-  }
-
-  componentDidMount () {
-    this.startNewGame();
-  }
-
-  startNewGame () {
-    const { game: { numberOfCards, deck }, cards } = this.props;
-
-    // loop through current deck and set flip to false so
-    // new deck does not show before render
-    deck.forEach((element, i) => {
-      if (element.isFlipped) {
-        console.log('Flipping ' + i)
-        this.props.cardFlip(i);
-      }
-    });
-
-    const newDeck = newGame(cards, numberOfCards);
-    this.props.addNewDeck(newDeck);
   }
   
   cardFlip (index) {
@@ -85,10 +63,6 @@ class Game extends Component {
 
     return (
       <div>
-        <Options 
-          isGameComplete={numberOfCards === cardsMatched}
-          score={score} 
-          startNewGame={this.startNewGame} />
         <DeckWrapper>
           {deck.map((card, i) => <Card key={ i } card={ card } onClick={() => this.cardFlip(i)} />) }
         </DeckWrapper>

--- a/client/components/Game.js
+++ b/client/components/Game.js
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 
 import Card from './Card';
 
-import newGame from '../utils/newGame';
-
 const DeckWrapper = styled.div`
   position: relative;
   max-width: 1000px;
@@ -25,13 +23,13 @@ class Game extends Component {
     const { deck, lastCardSelected } = this.props.game;
     const { isFlipped } = deck[index];
 
-    this.props.updateScore(1);
-
     if (isFlipped) {
       // I decided that I don't want people unflipping cards
       return;
     } 
 
+    this.props.updateScore(1);
+    
     // flip card
     this.props.cardFlip(index);
     
@@ -59,7 +57,7 @@ class Game extends Component {
   }
   
   render () {
-    const { deck, score, numberOfCards, cardsMatched } = this.props.game;
+    const { deck } = this.props.game;
 
     return (
       <div>

--- a/client/components/Game.js
+++ b/client/components/Game.js
@@ -11,6 +11,7 @@ const DeckWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  padding: 20px;
 `;
 
 class Game extends Component {
@@ -60,7 +61,7 @@ class Game extends Component {
     const { deck } = this.props.game;
 
     return (
-      <div>
+      <div class="game-wrapper">
         <DeckWrapper>
           {deck.map((card, i) => <Card key={ i } card={ card } onClick={() => this.cardFlip(i)} />) }
         </DeckWrapper>

--- a/client/components/Main.js
+++ b/client/components/Main.js
@@ -1,13 +1,50 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 
+import Options from './Options';
+
+import newGame from '../utils/newGame';
+
 class Main extends Component {
+  constructor (props) {
+    super(props);
+    this.startNewGame = this.startNewGame.bind(this);
+  }
+
+  componentDidMount () {
+    this.startNewGame();
+  }
+
+  startNewGame () {
+    const { game: { numberOfCards, deck }, cards } = this.props;
+
+    // loop through current deck and set flip to false so
+    // new deck does not show before render
+    deck.forEach((element, i) => {
+      if (element.isFlipped) {
+        console.log('Flipping ' + i)
+        this.props.cardFlip(i);
+      }
+    });
+
+    const newDeck = newGame(cards, numberOfCards);
+    this.props.addNewDeck(newDeck);
+  }
+  
   render () {
+    const { deck, score, numberOfCards, cardsMatched } = this.props.game;
+
     return (
       <div>
-        <h1>
-          <Link to="/">Pairs</Link>
-        </h1>
+        <div className="header">
+          <h1>
+            <Link to="/">Pairs</Link>
+          </h1>
+          <Options 
+            isGameComplete={numberOfCards === cardsMatched}
+            score={score} 
+            startNewGame={this.startNewGame} />
+        </div>
         { React.cloneElement(this.props.children, this.props) }
       </div>
     );

--- a/client/components/Main.js
+++ b/client/components/Main.js
@@ -36,7 +36,7 @@ class Main extends Component {
 
     return (
       <div>
-        <div className="header">
+        <header>
           <h1>
             <Link to="/">Pairs</Link>
           </h1>
@@ -44,7 +44,7 @@ class Main extends Component {
             isGameComplete={numberOfCards === cardsMatched}
             score={score} 
             startNewGame={this.startNewGame} />
-        </div>
+        </header>
         { React.cloneElement(this.props.children, this.props) }
       </div>
     );

--- a/client/styles/style.styl
+++ b/client/styles/style.styl
@@ -2,9 +2,21 @@
 @import '_typography.styl'
 @import '_animations.styl'
 
+*
+  box-sizing  border-box
+
 body
   background #eff5f5
   
+header {
+  position absolute
+  width 250px
+  background rgba(100,100,100,0.1)
+  text-align center
+  padding 15px
+  height 100%
+}
+
 .options
   text-align center
   margin-bottom 2rem
@@ -16,3 +28,7 @@ body
   .game-complete
     font-size 3rem
     color red
+
+.game-wrapper {
+  margin-left 250px
+}


### PR DESCRIPTION
Move the header out of `game.js` and into `main.js`. Add styling so that header now sits in a sidebar.

Also, fix an issue where the score was updating when clicking on flipped cards.